### PR TITLE
19913: OpenHBX Cv2 gem does not expose enrollment event headers

### DIFF
--- a/lib/openhbx/cv2/enrollment_event.rb
+++ b/lib/openhbx/cv2/enrollment_event.rb
@@ -8,6 +8,7 @@ module Openhbx
       tag 'enrollment_event'
       namespace 'cv'
 
+      has_one :header, ::Openhbx::Cv2::EnrollmentEventHeader, tag: "header"
       has_one :event, ::Openhbx::Cv2::EnrollmentEventEvent, tag: "event"
     end
   end

--- a/lib/openhbx/cv2/enrollment_event_header.rb
+++ b/lib/openhbx/cv2/enrollment_event_header.rb
@@ -1,0 +1,14 @@
+module Openhbx
+  module Cv2
+    class EnrollmentEventHeader
+      include HappyMapper
+      include ::Openhbx::Cv2::Namespace
+
+      register_namespace "cv", NS_URI
+      tag 'header'
+      namespace 'cv'
+
+      element "submitted_timestamp", String, tag: "submitted_timestamp"
+    end
+  end
+end

--- a/lib/openhbx_cv2.rb
+++ b/lib/openhbx_cv2.rb
@@ -41,6 +41,7 @@ module Openhbx
     autoload :TaxHousehold
     autoload :TaxHouseholdMember
     autoload :EnrollmentEvent
+    autoload :EnrollmentEventHeader
     autoload :EnrollmentEventEvent
     autoload :EnrollmentEventBody
     autoload :Enrollment

--- a/spec/openhbx/cv2/enrollment_event_header_spec.rb
+++ b/spec/openhbx/cv2/enrollment_event_header_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe Openhbx::Cv2::EnrollmentEventHeader, "given a sample xml" do
+  let(:input_xml) { 
+<<-XMLDOC
+<?xml version='1.0' encoding='utf-8' ?>
+<header xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns='http://openhbx.org/api/terms/1.0'>
+  <submitted_timestamp>#{submitted_timestamp}</submitted_timestamp>
+</header>
+XMLDOC
+  }
+
+  let(:submitted_timestamp) { "A TIMESTAMP" }
+
+  subject { Openhbx::Cv2::EnrollmentEventHeader.parse(input_xml, single: true) }
+
+  it "has the correct timestamp" do
+    expect(subject.submitted_timestamp).to eq(submitted_timestamp)
+  end
+end

--- a/spec/openhbx/cv2/enrollment_event_spec.rb
+++ b/spec/openhbx/cv2/enrollment_event_spec.rb
@@ -5,6 +5,7 @@ describe Openhbx::Cv2::EnrollmentEvent, "given a sample xml" do
 <<-XMLDOC
 <?xml version='1.0' encoding='utf-8' ?>
 <enrollment_event xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns='http://openhbx.org/api/terms/1.0'>
+  <header/>
   <event />
 </enrollment_event>
 XMLDOC
@@ -12,7 +13,11 @@ XMLDOC
 
   subject { Openhbx::Cv2::EnrollmentEvent.parse(input_xml, single: true) }
 
-  it "has the correct policy id" do
+  it "has the correct header" do
+    expect(subject.header).to be_kind_of Openhbx::Cv2::EnrollmentEventHeader
+  end
+
+  it "has the correct event" do
     expect(subject.event).to be_kind_of Openhbx::Cv2::EnrollmentEventEvent
   end
 end

--- a/spec/openhbx/cv2/plan_link_spec.rb
+++ b/spec/openhbx/cv2/plan_link_spec.rb
@@ -76,7 +76,6 @@ XMLDOC
   end
 
   it "has the second alias id" do
-    puts "#{subject.alias_ids}"
     expect(subject.alias_ids).to include alias_id_2
   end
 end


### PR DESCRIPTION
|Field|Value|
|-----|-----|
| Redmine Ticket Number | [19913](https://devops.dchbx.org/redmine/issues/19913) |
| App-Dev Road Map # | n/a |
| Start Date | n/a |
| Due Date | n/a  |
| App-Dev Priority | UP-Disqueued |
| Development Story Points | 0.5 |
| Peer Review Story Points | n/a |
| Ticket Author | @TreyE |